### PR TITLE
- adds logic to unpack / pack

### DIFF
--- a/Capnp.Net.Runtime/Framing.cs
+++ b/Capnp.Net.Runtime/Framing.cs
@@ -23,7 +23,7 @@ namespace Capnp
         /// <exception cref="IOException">An I/O error occurs.</exception>
         /// <exception cref="InvalidDataException">Encountered invalid framing data, too many or too large segments</exception>
         /// <exception cref="OutOfMemoryException">Too many or too large segments, probably due to invalid framing data.</exception>
-        public static WireFrame ReadSegments(Stream stream, bool isPacked)
+        public static WireFrame ReadSegments(Stream stream, bool isPacked = false)
         {
             if (isPacked)
             {

--- a/Capnp.Net.Runtime/PackedStream.cs
+++ b/Capnp.Net.Runtime/PackedStream.cs
@@ -1,0 +1,92 @@
+﻿using System.IO;
+
+namespace Capnp
+{
+    public static class PackedStream
+    {
+        private const byte cEmptyByte = 0x00;
+        private const byte cBit = 0x01;
+
+        public static MemoryStream Pack(MemoryStream data)
+        {
+            MemoryStream packedStream = new MemoryStream();
+
+            using (BinaryReader reader = new BinaryReader(data))
+            {
+                PackStream(reader, packedStream);
+                packedStream.Seek(0, SeekOrigin.Begin);
+                return packedStream;
+            }
+        }
+
+        public static MemoryStream Pack(byte[] data)
+        {
+            return Pack(new MemoryStream(data));
+        }
+
+        private static void PackStream(BinaryReader reader, MemoryStream packedStream)
+        {
+            if (reader.BaseStream.Position >= reader.BaseStream.Length)
+            {
+                return;
+            }
+
+            byte tag = cEmptyByte;
+            byte valueCount = cEmptyByte;
+            byte[] valueBytes = new byte[8];
+
+            for (byte i = 0; i < 8; i++)
+            {
+                if (reader.BaseStream.Position <= reader.BaseStream.Length)
+                {
+                    byte currentByte = reader.ReadByte();
+                    if (currentByte != cEmptyByte)
+                    {
+                        tag += (byte)(cBit << i);
+                        valueBytes[valueCount] = currentByte;
+                        valueCount++;
+                    }
+                }
+            }
+
+            packedStream.WriteByte(tag);
+
+            if (tag == cEmptyByte)
+            {
+                packedStream.WriteByte(CountZeroWords(reader, 0));
+            }
+            else
+            {
+                packedStream.Write(valueBytes, 0, valueCount);
+            }
+
+            PackStream(reader, packedStream);
+        }
+
+        private static byte CountZeroWords(BinaryReader reader, byte emptyWordCount)
+        {
+            bool wordIsEmpty = true;
+            long startPos = reader.BaseStream.Position;
+
+            for (byte i = 0; i < 8; i++)
+            {
+                if (startPos + i < reader.BaseStream.Length)
+                {
+                    if (reader.ReadByte() != cEmptyByte)
+                    {
+                        wordIsEmpty = false;
+                        reader.BaseStream.Seek(startPos, SeekOrigin.Current);
+                        break;
+                    }
+                }
+            }
+
+            if (wordIsEmpty)
+            {
+                return CountZeroWords(reader, (byte)(emptyWordCount + 1));
+            }
+
+            return emptyWordCount;
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to pack and unpack a memorystream or byte[] using the packing scheme explained [here](https://capnproto.org/encoding.html#packing). 

Packing using the `0xff` tag is not yet implemented.