### PR TITLE
Linux support

### DIFF
--- a/Capnp.Net.Runtime.Tests.Core21/Capnp.Net.Runtime.Tests.Core21.csproj
+++ b/Capnp.Net.Runtime.Tests.Core21/Capnp.Net.Runtime.Tests.Core21.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/CapnpC.CSharp.Generator.Tests/CapnpC.CSharp.Generator.Tests.csproj
+++ b/CapnpC.CSharp.Generator.Tests/CapnpC.CSharp.Generator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>CapnpC.CSharp.Generator.Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/CapnpC.CSharp.Generator.Tests/FeatureSteps/CodeGeneratorSteps.cs
+++ b/CapnpC.CSharp.Generator.Tests/FeatureSteps/CodeGeneratorSteps.cs
@@ -27,16 +27,27 @@ namespace CapnpC.CSharp.Generator.Tests
             return assembly.GetManifestResourceStream(urn);
         }
 
-        internal static bool IsCapnpExeInstalled()
+        internal static bool IsCapnpInstalled()
         {
-            using (var process = Process.Start("where", "capnp.exe"))
+            try
             {
-                if (process == null)
-                    Assert.Fail("Unable to start 'where'");
+                var startInfo = new ProcessStartInfo(CapnpCompilation.CapnpCompilerFilename, "--version");
+                startInfo.UseShellExecute = false;
+                startInfo.RedirectStandardOutput = true;
+                startInfo.RedirectStandardError = true;
 
-                process.WaitForExit();
+                using (var process = Process.Start(startInfo))
+                {
+                    Assert.IsNotNull(process, $"Unable to start '{CapnpCompilation.CapnpCompilerFilename}'");
 
-                return process.ExitCode == 0;
+                    process.WaitForExit();
+
+                    return process.ExitCode == 0;
+                }
+            }
+            catch (Exception)
+            {
+                return false;
             }
         }
 
@@ -112,9 +123,9 @@ namespace CapnpC.CSharp.Generator.Tests
         [Given(@"capnp\.exe is installed on my system")]
         public void GivenCapnp_ExeIsInstalledOnMySystem()
         {
-            if (!IsCapnpExeInstalled())
+            if (!IsCapnpInstalled())
             {
-                Assert.Inconclusive("capnp.exe not found. Precondition of this test is not met.");
+                Assert.Inconclusive("Capnp compiler not found. Precondition of this test is not met.");
             }
         }
 
@@ -151,9 +162,9 @@ namespace CapnpC.CSharp.Generator.Tests
         [Given(@"capnp\.exe is not installed on my system")]
         public void GivenCapnp_ExeIsNotInstalledOnMySystem()
         {
-            if (IsCapnpExeInstalled())
+            if (IsCapnpInstalled())
             {
-                Assert.Inconclusive("capnp.exe found. Precondition of this test is not met.");
+                Assert.Inconclusive("Capnp compiler found. Precondition of this test is not met.");
             }
         }
 

--- a/CapnpC.CSharp.Generator.Tests/Util/InlineAssemblyCompiler.cs
+++ b/CapnpC.CSharp.Generator.Tests/Util/InlineAssemblyCompiler.cs
@@ -22,7 +22,12 @@ namespace CapnpC.CSharp.Generator.Tests.Util
 
             string capnpRuntimePath = Path.GetFullPath(Path.Combine(
                 Assembly.GetExecutingAssembly().Location,
-                @"..\..\..\..\..\Capnp.Net.Runtime\bin\Debug\netcoreapp2.1\Capnp.Net.Runtime.dll"));
+                "..", "..", "..", "..", "..",
+                "Capnp.Net.Runtime",
+                "bin",
+                "Debug",
+                "netcoreapp2.1",
+                "Capnp.Net.Runtime.dll"));
 
             var capnpRuntimeMetadataRef = MetadataReference.CreateFromFile(capnpRuntimePath);
 

--- a/CapnpC.CSharp.Generator/CapnpCompilation.cs
+++ b/CapnpC.CSharp.Generator/CapnpCompilation.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 [assembly: InternalsVisibleTo("CapnpC.CSharp.Generator.Tests")]
@@ -15,6 +16,14 @@ namespace CapnpC.CSharp.Generator
     /// </summary>
     public static class CapnpCompilation
     {
+        /// <summary>
+        /// Returns the basename of the capnp executable
+        /// </summary>
+        public static string CapnpCompilerFilename
+        {
+            get => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "capnp.exe" : "capnp";
+        }
+
         /// <summary>
         /// Generates C# code from given input stream
         /// </summary>
@@ -60,7 +69,7 @@ namespace CapnpC.CSharp.Generator
                 argList.Add($"-o-");
                 argList.AddRange(arguments);
 
-                compiler.StartInfo.FileName = "capnp.exe";
+                compiler.StartInfo.FileName = CapnpCompilerFilename;
                 compiler.StartInfo.Arguments = string.Join(" ", argList);
                 compiler.StartInfo.UseShellExecute = false;
                 compiler.StartInfo.RedirectStandardOutput = true;

--- a/CapnpC.CSharp.Generator/CodeGen/CodeGenerator.cs
+++ b/CapnpC.CSharp.Generator/CodeGen/CodeGenerator.cs
@@ -210,7 +210,7 @@
 
             cu = cu.AddMembers(ns);
 
-            return cu.NormalizeWhitespace().ToFullString();
+            return cu.NormalizeWhitespace("    ", Environment.NewLine).ToFullString();
         }
 
         public IReadOnlyList<FileGenerationResult> Generate()

--- a/CapnpC.CSharp.MsBuild.Generation.Tests/CapnpC.CSharp.MsBuild.Generation.Tests.csproj
+++ b/CapnpC.CSharp.MsBuild.Generation.Tests/CapnpC.CSharp.MsBuild.Generation.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/CapnpC.CSharp.MsBuild.Generation/CapnpC.CSharp.MsBuild.Generation.csproj
+++ b/CapnpC.CSharp.MsBuild.Generation/CapnpC.CSharp.MsBuild.Generation.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="rmdir /s /q $(SolutionDir)MsBuildGenerationTest\obj" />
+    <RemoveDir Directories="$(SolutionDir)\MsBuildGenerationTest\obj" />
   </Target>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,13 +56,13 @@ artifacts:
    type: NuGetPackage
 clone_depth: 1
 test_script:
-  - cmd: vstest.console /logger:Appveyor /inIsolation CapnpC.CSharp.Generator.Tests\bin\Release\netcoreapp2.2\CapnpC.CSharp.Generator.Tests.dll
+  - cmd: vstest.console /logger:Appveyor /inIsolation CapnpC.CSharp.Generator.Tests\bin\Release\netcoreapp2.1\CapnpC.CSharp.Generator.Tests.dll
   - cmd: cd %APPVEYOR_BUILD_FOLDER%\chocolatey\install
   - cmd: choco install capnpc-csharp --source=".;https://chocolatey.org/api/v2" --force -y
   - cmd: cd %APPVEYOR_BUILD_FOLDER%\install-test
   - cmd: compile-test
   - cmd: cd %APPVEYOR_BUILD_FOLDER%
-  - cmd: vstest.console /logger:Appveyor /inIsolation CapnpC.CSharp.Generator.Tests\bin\Release\netcoreapp2.2\CapnpC.CSharp.Generator.Tests.dll
+  - cmd: vstest.console /logger:Appveyor /inIsolation CapnpC.CSharp.Generator.Tests\bin\Release\netcoreapp2.1\CapnpC.CSharp.Generator.Tests.dll
   - cmd: choco uninstall capnpc-csharp -y
   - cmd: cd %APPVEYOR_BUILD_FOLDER%\install-test
   - cmd: notinstalled-test
@@ -73,13 +73,13 @@ test_script:
   - cmd: choco uninstall capnpc-csharp-win-x86 -y
   - cmd: notinstalled-test
   - cmd: cd %APPVEYOR_BUILD_FOLDER%
-  - cmd: vstest.console /logger:Appveyor /inIsolation CapnpC.CSharp.MsBuild.Generation.Tests\bin\Release\netcoreapp2.2\CapnpC.CSharp.MsBuild.Generation.Tests.dll
+  - cmd: vstest.console /logger:Appveyor /inIsolation CapnpC.CSharp.MsBuild.Generation.Tests\bin\Release\netcoreapp2.1\CapnpC.CSharp.MsBuild.Generation.Tests.dll
   - cmd: msbuild -t:restore ./MsBuildGenerationTest/MsBuildGenerationTest.csproj /p:Configuration="Debug" /p:PackageReferenceVersion="%APPVEYOR_BUILD_VERSION%"
   - cmd: msbuild ./MsBuildGenerationTest/MsBuildGenerationTest.sln /p:Configuration="Debug" /p:PackageReferenceVersion="%APPVEYOR_BUILD_VERSION%"
   - cmd: vstest.console /logger:Appveyor /inIsolation Capnp.Net.Runtime.Tests\bin\Debug\net471\Capnp.Net.Runtime.Tests.Std20.dll
   - cmd: vstest.console /logger:Appveyor /inIsolation Capnp.Net.Runtime.Tests\bin\Release\net471\Capnp.Net.Runtime.Tests.Std20.dll
-  - cmd: vstest.console /logger:Appveyor /inIsolation Capnp.Net.Runtime.Tests.Core21\bin\Debug\netcoreapp2.2\Capnp.Net.Runtime.Tests.Core21.dll
-  - cmd: vstest.console /logger:Appveyor /inIsolation Capnp.Net.Runtime.Tests.Core21\bin\Release\netcoreapp2.2\Capnp.Net.Runtime.Tests.Core21.dll
+  - cmd: vstest.console /logger:Appveyor /inIsolation Capnp.Net.Runtime.Tests.Core21\bin\Debug\netcoreapp2.1\Capnp.Net.Runtime.Tests.Core21.dll
+  - cmd: vstest.console /logger:Appveyor /inIsolation Capnp.Net.Runtime.Tests.Core21\bin\Release\netcoreapp2.1\Capnp.Net.Runtime.Tests.Core21.dll
 on_finish :
   # any cleanup in here
 deploy:


### PR DESCRIPTION
Hi, the following changes are required on my Ubuntu 18.04 system to make the tests pass under Linux. 

* I don't have access to a Windows box, so please make sure I haven't broken anything there! :)
* I changed the target dotnet core version from 2.2 -> 2.1 in some places, because 2.2 doesn't seem to be strictly required, and it's easier to have a single SDK version rather than a mix (each separate version SDK is a few hundred MB install on Linux). I might be missing something about why it's required, though. 

Happy to make further changes as needed, thanks!