### PR TITLE
Quote all arguments, not just import paths

### DIFF
--- a/CapnpC.CSharp.Generator/CapnpCompilation.cs
+++ b/CapnpC.CSharp.Generator/CapnpCompilation.cs
@@ -76,7 +76,10 @@ namespace CapnpC.CSharp.Generator
                 var argList = new List<string>();
                 argList.Add("compile");
                 argList.Add($"-o-");
-                argList.AddRange(arguments);
+                foreach (var arg in arguments)
+                {
+                    argList.Add($"\"{arg.TrimEnd('\\')}\"");
+                }
 
                 compiler.StartInfo.FileName = CapnpCompilerFilename;
                 compiler.StartInfo.Arguments = string.Join(" ", argList);

--- a/CapnpC.CSharp.MsBuild.Generation/GenerateCapnpFileCodeBehindTask.cs
+++ b/CapnpC.CSharp.MsBuild.Generation/GenerateCapnpFileCodeBehindTask.cs
@@ -41,7 +41,7 @@ namespace CapnpC.CSharp.MsBuild.Generation
             if (!string.IsNullOrWhiteSpace(importPaths))
             {
                 job.AdditionalArguments.AddRange(importPaths.Split(new char[] { ';' }, 
-                    StringSplitOptions.RemoveEmptyEntries).Select(p => $"-I\"{p.TrimEnd('\\')}\""));
+                    StringSplitOptions.RemoveEmptyEntries).Select(p => $"-I{p}"));
             }
 
             string sourcePrefix = item.GetMetadata("SourcePrefix");


### PR DESCRIPTION
When the path .capnp file passed to the compiler contains spaces (e.g.
`C:\Users\Full Name\source\repos\...`) the argument was not quoted
causing it to be misinterpreted as multiple arguments.

.net sdk 5.0 adds a new ArgumentsList property to ProcessStartInfo which
can handle more edge cases. This has been tested but not implemented in
order to avoid changing the projects, instead this commit only moves the
rudimentary quoting already applied to import paths so that it applies
to all arguments.