### PR TITLE
AddRef() to elements of a :List(Capability)

### DIFF
--- a/Capnp.Net.Runtime.Tests/Mock/TestCapImplementations.cs
+++ b/Capnp.Net.Runtime.Tests/Mock/TestCapImplementations.cs
@@ -1434,5 +1434,28 @@ namespace Capnp.Net.Runtime.Tests.GenImpls
         }
     }
 
+
+    class Issue62Impl : IIssue62
+
+    {
+        public Task<IReadOnlyList<Issue62.ICapElement>> ListOfCaps(CancellationToken cancellationToken_ = default)
+            => Task.FromResult(new Issue62.ICapElement[] { new ICapElementImpl() } as IReadOnlyList<Issue62.ICapElement>);
+
+        public void Dispose()
+        {
+        }
+
+        class ICapElementImpl : Issue62.ICapElement
+        {
+            public void Dispose()
+            {
+            }
+
+            public async Task Method(CancellationToken cancellationToken_ = default)
+            {
+            }
+        }
+    }
+
     #endregion
 }

--- a/Capnp.Net.Runtime/DeserializerState.cs
+++ b/Capnp.Net.Runtime/DeserializerState.cs
@@ -609,7 +609,9 @@ namespace Capnp
         /// non-list-of-pointers pointer, traversal limit exceeded</exception>
         public ListOfCapsDeserializer<T> ReadCapList<T>(int index) where T : class
         {
-            return StructReadPointer(index).RequireCapList<T>();
+            var list = StructReadPointer(index).RequireCapList<T>();
+            list.AddRef();
+            return list;
         }
 
         /// <summary>

--- a/Capnp.Net.Runtime/ListOfCapsDeserializer.cs
+++ b/Capnp.Net.Runtime/ListOfCapsDeserializer.cs
@@ -16,6 +16,15 @@ namespace Capnp
             Rpc.CapabilityReflection.ValidateCapabilityInterface(typeof(T));
         }
 
+        internal void AddRef()
+        {
+            int count = Count;
+            for (var i = 0; i < count; i++)
+            {
+                State.DecodeCapPointer(i).AddRef();
+            }
+        }
+
         /// <summary>
         /// Returns the capability at given index.
         /// </summary>

--- a/CapnpC.CSharp.Generator/CapnpCompilation.cs
+++ b/CapnpC.CSharp.Generator/CapnpCompilation.cs
@@ -76,7 +76,10 @@ namespace CapnpC.CSharp.Generator
                 var argList = new List<string>();
                 argList.Add("compile");
                 argList.Add($"-o-");
-                argList.AddRange(arguments);
+                foreach (var arg in arguments)
+                {
+                    argList.Add($"\"{arg.TrimEnd('\\')}\"");
+                }
 
                 compiler.StartInfo.FileName = CapnpCompilerFilename;
                 compiler.StartInfo.Arguments = string.Join(" ", argList);

--- a/CapnpC.CSharp.MsBuild.Generation/GenerateCapnpFileCodeBehindTask.cs
+++ b/CapnpC.CSharp.MsBuild.Generation/GenerateCapnpFileCodeBehindTask.cs
@@ -41,7 +41,7 @@ namespace CapnpC.CSharp.MsBuild.Generation
             if (!string.IsNullOrWhiteSpace(importPaths))
             {
                 job.AdditionalArguments.AddRange(importPaths.Split(new char[] { ';' }, 
-                    StringSplitOptions.RemoveEmptyEntries).Select(p => $"-I\"{p.TrimEnd('\\')}\""));
+                    StringSplitOptions.RemoveEmptyEntries).Select(p => $"-I{p}"));
             }
 
             string sourcePrefix = item.GetMetadata("SourcePrefix");

--- a/MsBuildGenerationTest/Issue62.capnp
+++ b/MsBuildGenerationTest/Issue62.capnp
@@ -1,0 +1,12 @@
+﻿@0x84b3d81482a93cd8;
+
+
+interface Issue62
+{
+	listOfCaps @0 () -> (result :List(CapElement));
+
+	interface CapElement
+	{
+		method @0 () -> ();
+	}
+}


### PR DESCRIPTION
When reading a list of capabilities, add another implicit reference to account for the result of the call, otherwise the underlying capabilities are released which results in an exception being thrown when the list is accessed and newly constructed proxies attempt to bind to the elements.

Closes #62 

Currently based on #61 because I needed that to generate the code for the failing test's capnp file.